### PR TITLE
fix: add supabase server client and correct imports

### DIFF
--- a/app/user/actions.ts
+++ b/app/user/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { createClient } from '@/lib/utils/supabase/server';
+import { createClient } from '@/utils/supabase/server';
 
 export async function getCurrentUserEmail(): Promise<string | null> {
   try {

--- a/lib/organization-service.ts
+++ b/lib/organization-service.ts
@@ -1,5 +1,5 @@
 import { db } from './db';
-import { createClient } from '@/lib/utils/supabase/server';
+import { createClient } from '@/utils/supabase/server';
 
 // Simple in-memory cache for current user (lasts for the duration of request)
 let currentUserCache: { user: any; timestamp: number } | null = null;

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,0 +1,27 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export async function createClient() {
+  const cookieStore = cookies()
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            )
+          } catch {
+            // cookies may be unavailable in some environments
+          }
+        }
+      }
+    }
+  )
+}


### PR DESCRIPTION
## Summary
- fix server-side Supabase import paths
- add server utility for creating Supabase client

## Testing
- `pnpm run test` *(fails: Missing script: test)*
- `pnpm run type-check` *(fails: Missing script: type-check)*
- `pnpm lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ae26c409cc8325b89f80fb08a7cab5