### PR TITLE
Add formatFileSize tests and zero-byte handling

### DIFF
--- a/components/projects/ProjectDocuments.tsx
+++ b/components/projects/ProjectDocuments.tsx
@@ -110,6 +110,21 @@ const getPillText = (fileType: string): string => {
 
 const INITIAL_DOCUMENTS_SHOWN = 12;
 
+export const formatFileSize = (bytes?: number) => {
+  if (bytes === undefined) return 'Unknown size';
+
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let size = bytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+
+  return `${Math.round(size * 100) / 100} ${units[unitIndex]}`;
+};
+
 export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
   const [documents, setDocuments] = useState<ProjectDocument[]>([]);
   const [projectIndexes, setProjectIndexes] = useState<ProjectIndex[]>([]);
@@ -260,20 +275,6 @@ export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
     }));
   };
 
-  const formatFileSize = (bytes?: number) => {
-    if (!bytes) return 'Unknown size';
-    
-    const units = ['B', 'KB', 'MB', 'GB'];
-    let size = bytes;
-    let unitIndex = 0;
-    
-    while (size >= 1024 && unitIndex < units.length - 1) {
-      size /= 1024;
-      unitIndex++;
-    }
-    
-    return `${Math.round(size * 100) / 100} ${units[unitIndex]}`;
-  };
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('en-US', {

--- a/components/projects/__tests__/ProjectDocuments.test.tsx
+++ b/components/projects/__tests__/ProjectDocuments.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatFileSize } from '../ProjectDocuments';
+
+describe('formatFileSize', () => {
+  it('returns "0 B" for 0 bytes', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+  });
+
+  it('returns "2 KB" for 2048 bytes', () => {
+    expect(formatFileSize(2048)).toBe('2 KB');
+  });
+});
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import path from 'path';
+
+export default {
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
+};
+


### PR DESCRIPTION
## Summary
- export `formatFileSize` utility and handle 0-byte inputs
- add vitest config with `@` path alias
- test `formatFileSize` for 0 bytes and kilobyte conversion

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_68ae31dda72883258523b3c34e07dc49