### PR TITLE
fix: handle null file size

### DIFF
--- a/components/projects/ProjectDocuments.tsx
+++ b/components/projects/ProjectDocuments.tsx
@@ -111,7 +111,7 @@ const getPillText = (fileType: string): string => {
 const INITIAL_DOCUMENTS_SHOWN = 12;
 
 export const formatFileSize = (bytes?: number) => {
-  if (bytes === undefined) return 'Unknown size';
+  if (bytes === undefined || bytes === null) return 'Unknown size';
 
   const units = ['B', 'KB', 'MB', 'GB'];
   let size = bytes;


### PR DESCRIPTION
## Summary
- handle null or undefined file size in ProjectDocuments formatting

## Testing
- `npx vitest run components/projects/__tests__/ProjectDocuments.test.tsx`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_b_68ae31da8a108325a4823abbe955e352